### PR TITLE
aom: exclude paths for examples and third party

### DIFF
--- a/aom/exclude-paths.txt
+++ b/aom/exclude-paths.txt
@@ -1,0 +1,2 @@
+^aom-[^/]*/examples/
+^aom-[^/]*/third_party/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/51825/