### PR TITLE
lvm2: exclude path to testsuite code

### DIFF
--- a/lvm2/exclude-paths.txt
+++ b/lvm2/exclude-paths.txt
@@ -1,0 +1,1 @@
+^/usr/share/lvm2-testsuite/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52341/