### PR TITLE
gssproxy: exclude path to tests directory

### DIFF
--- a/gssproxy/exclude-paths.txt
+++ b/gssproxy/exclude-paths.txt
@@ -1,0 +1,1 @@
+^gssproxy-[^/]*/tests/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52032/