### PR TITLE
libconfig: exclude paths to examples and tests

### DIFF
--- a/libconfig/exclude-paths.txt
+++ b/libconfig/exclude-paths.txt
@@ -1,0 +1,3 @@
+^-libconfig[^/]*/examples/
+^-libconfig[^/]*/tests/
+^-libconfig[^/]*/tinytest/


### PR DESCRIPTION
... directories.

Related: https://openscanhub.fedoraproject.org/task/52233/