### PR TITLE
libunwind: exclude paths to tests directory

### DIFF
--- a/libunwind/exclude-paths.txt
+++ b/libunwind/exclude-paths.txt
@@ -1,0 +1,1 @@
+^libunwind-[^/]*/tests/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52311/