### PR TITLE
ostree: exclude path to installed tests

### DIFF
--- a/ostree/exclude-paths.txt
+++ b/ostree/exclude-paths.txt
@@ -1,0 +1,1 @@
+^/usr/libexec/installed-tests/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52408/