### PR TITLE
firewalld: exclude path to testsuite directory

### DIFF
--- a/firewalld/exclude-paths.txt
+++ b/firewalld/exclude-paths.txt
@@ -1,0 +1,1 @@
+^/usr/share/firewalld/testsuite/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/51961/