### PR TITLE
flatpak: exclude paths to installed-tests directory

### DIFF
--- a/flatpak/exclude-paths.txt
+++ b/flatpak/exclude-paths.txt
@@ -1,0 +1,1 @@
+^/usr/libexec/installed-tests/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/51962/