### PR TITLE
libssh2: exclude path to example directory

### DIFF
--- a/libssh2/exclude-paths.txt
+++ b/libssh2/exclude-paths.txt
@@ -1,0 +1,1 @@
+^libssh2-[^/]*/example/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/23126/