### PR TITLE
qt6-qtwebengine: exclude paths to third party code

### DIFF
--- a/qt6-qtwebengine/exclude-paths.txt
+++ b/qt6-qtwebengine/exclude-paths.txt
@@ -1,0 +1,1 @@
+^qtwebengine-everywhere-src-[^/]*/.*/(3rdparty|third_party)/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52539/