### PR TITLE
qt6-qtshadertools: exclude path to third party code

### DIFF
--- a/qt6-qtshadertools/exclude-paths.txt
+++ b/qt6-qtshadertools/exclude-paths.txt
@@ -1,0 +1,1 @@
+^qtshadertools-everywhere-src-[^/]*/src/3rdparty/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52526/