### PR TITLE
libvirt: exclude paths to tests and examples

### DIFF
--- a/libvirt/exclude-paths.txt
+++ b/libvirt/exclude-paths.txt
@@ -1,0 +1,2 @@
+^libvirt-[^/]*/tests
+^libvirt-[^/]*/examples


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52315/