### PR TITLE
libvncserver: exclude paths to examples and tests

### DIFF
--- a/libvncserver/exclude-paths.txt
+++ b/libvncserver/exclude-paths.txt
@@ -1,0 +1,2 @@
+^libvncserver-LibVNCServer-[^/]*/examples
+^libvncserver-LibVNCServer-[^/]*/test


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52316/