### PR TITLE
gnupg2: exclude path to tests directory

### DIFF
--- a/gnupg2/exclude-paths.txt
+++ b/gnupg2/exclude-paths.txt
@@ -1,0 +1,1 @@
+^gnupg-[^/]*/tests/


### PR DESCRIPTION
Related: https://openscanhub.fedoraproject.org/task/52019