### PR TITLE
exiv2: exclude path to xmpsdk directory

### DIFF
--- a/exiv2/exclude-paths.txt
+++ b/exiv2/exclude-paths.txt
@@ -1,0 +1,2 @@
+^exiv2-[^/]*/xmpsdk/
+# Third party sources


### PR DESCRIPTION
... as it contains third party sources.

Related: https://github.com/Exiv2/exiv2/pull/3276