### PR TITLE
[llvm] Exclude CMakeFiles/CMakeScratch/TryCompile CheckSymbolExists.c files

### DIFF
--- a/llvm/exclude-paths.txt
+++ b/llvm/exclude-paths.txt
@@ -1,0 +1,1 @@
+.*/CMakeFiles/CMakeScratch/TryCompile-[^/]*/CheckSymbolExists\.c


### PR DESCRIPTION
This ignores temporary cmake files that are only
meant to check if a symbol exists as a variable or function.

See https://cmake.org/cmake/help/latest/module/CheckSymbolExists.html

Here's an example how to verify that `CheckSymbolExists` is no longer found.

```console
$ cd /tmp
$ git clone -b llvm-ignore-cmake-try-compiles https://github.com/kwk/known-false-positives.git
$ wget -O llvm-scan-results.json https://openscanhub.fedoraproject.org/task/91528/log/llvm-21.1.8-1.fc44/scan-results.js?format=raw
$  csfilter-kfp llvm-scan-results.json --project-nvr llvm-21.1.8-1.fc44 --kfp-dir known-false-positives/ | grep CheckSymbolExists
```