### PR TITLE
[llvm] variables used `assert` are not unused

### DIFF
--- a/llvm/ignore.err
+++ b/llvm/ignore.err
@@ -30,3 +30,13 @@ llvm-project-21.1.8.src/llvm/include/llvm/Support/MathExtras.h:695: error[legacy
 #  696|   
 #  697|     T Product = SaturatingMultiply(X, Y, &Overflowed);
 
+Error: CLANG_WARNING: [#def72]
+llvm-project-21.1.8.src/llvm/lib/Transforms/Scalar/LoopInterchange.cpp:863:20: warning: unused variable 'OpCode' [-Wunused-variable]
+#  863 |           unsigned OpCode = RecurrenceDescriptor::getOpcode(RK);
+#      |                    ^~~~~~
+#  861|           case RecurKind::Add:
+#  862|           case RecurKind::Mul: {
+#  863|->           unsigned OpCode = RecurrenceDescriptor::getOpcode(RK);
+#  864|             SmallVector<Instruction *, 4> Ops = RD.getReductionOpChain(PHI, L);
+#  865|   
+

--- a/llvm/ignore.err
+++ b/llvm/ignore.err
@@ -40,3 +40,13 @@ llvm-project-21.1.8.src/llvm/lib/Transforms/Scalar/LoopInterchange.cpp:863:20: w
 #  864|             SmallVector<Instruction *, 4> Ops = RD.getReductionOpChain(PHI, L);
 #  865|   
 
+Error: CLANG_WARNING: [#def73]
+llvm-project-21.1.8.src/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp:702:13: warning: unused variable 'RedPhiRK' [-Wunused-variable]
+#  702 |   RecurKind RedPhiRK = RedPhiR->getRecurrenceKind();
+#      |             ^~~~~~~~
+#  700|       return false;
+#  701|   
+#  702|->   RecurKind RedPhiRK = RedPhiR->getRecurrenceKind();
+#  703|     assert((RedPhiRK == RecurKind::FMaxNum || RedPhiRK == RecurKind::FMinNum) &&
+#  704|            "unsupported reduction");
+


### PR DESCRIPTION
* `OpCode` IS used but only in an `assert()`.
   See here: https://github.com/llvm/llvm-project/blob/llvmorg-21.1.8/llvm/lib/Transforms/Scalar/LoopInterchange.cpp#L862-L880

* `RedPhiRK` variable used in assert is not unused
   See https://github.com/llvm/llvm-project/blob/llvmorg-21.1.8/llvm/lib/Transforms/Vectorize/VPlanConstruction.cpp#L702-L704
