### PR TITLE
[glibc] Exclude tests, benchtests, locales, and scripts

### DIFF
--- a/glibc/exclude-paths.txt
+++ b/glibc/exclude-paths.txt
@@ -4,3 +4,6 @@
 ^glibc-[^/]*/benchtests
 ^glibc-[^/]*/build-[^/]*/benchtests
 ^/usr/libexec/glibc-benchtests/glibc-bench-compare
+^glibc-[^/]*/localedata/locales
+^/usr/share/i18n/locales
+^/usr/bin

--- a/glibc/exclude-paths.txt
+++ b/glibc/exclude-paths.txt
@@ -1,3 +1,3 @@
-^glibc-[^/]*/.*/tst-'
-^glibc-[^/]*/.*/test-'
-^glibc-[^/]*/.*/bug-'
+^glibc-[^/]*/.*/tst-
+^glibc-[^/]*/.*/test-
+^glibc-[^/]*/.*/bug-

--- a/glibc/exclude-paths.txt
+++ b/glibc/exclude-paths.txt
@@ -1,3 +1,6 @@
 ^glibc-[^/]*/.*/tst-
 ^glibc-[^/]*/.*/test-
 ^glibc-[^/]*/.*/bug-
+^glibc-[^/]*/benchtests
+^glibc-[^/]*/build-[^/]*/benchtests
+^/usr/libexec/glibc-benchtests/glibc-bench-compare


### PR DESCRIPTION
Tests, benchtests:
For now, tests are excluded en-masse.  They might legitimately exercise error conditions, skip de-allocating resources before exit for simplicity, or the reported errors might be spurious.
* tests: Correct the excludions expression, removing trailing quotes
* benchtests: Exclude in-tree, generated, and installed artifacts

Locales: Locale data generates spurious unicontrol errors.

Scripts: Installed bash scripts generate spurious TEXTDOMAIN and other unused variable errors.